### PR TITLE
Add Triage and Review team charter.

### DIFF
--- a/active/triage-and-review.md
+++ b/active/triage-and-review.md
@@ -1,10 +1,10 @@
 # Triage and Review Team
 
-The Triage & Review Team assists with the processing of pull requests.
+The Triage & Review Team assists with the processing of pull requests, bug reports, and feature requests.
 
 ## Scope of responsibilities
 
-The objective of the team is to help spread work beyond the [Mergers](https://www.djangoproject.com/foundation/teams/#mergers-team) and into the wider contributor community. A pull request approval from a member of the Triage and Review team allows a Merger to merge a minor change.
+The objective of the team is to help spread work beyond the [Mergers](https://www.djangoproject.com/foundation/teams/#mergers-team) and into the wider contributor community. A pull request approval from a member of the Triage and Review team allows a Merger to merge a minor change that they, themselves have primarily authored.
 
 Team members will:
 

--- a/active/triage-and-review.md
+++ b/active/triage-and-review.md
@@ -45,7 +45,7 @@ There are [instructions on how to add new members to the team in the Wiki](https
 
 There is no budget, but requests can be made to the Board as needs arise.
 
-Django has some professional PyCharm licenses that we can share with our contributors. Team members are eligible receive these.
+Django has some professional PyCharm licenses that we can share with our contributors. Team members are eligible to receive these.
 
 ## Comms
 

--- a/active/triage-and-review.md
+++ b/active/triage-and-review.md
@@ -4,7 +4,7 @@ The Triage & Review Team assists with the processing of pull requests, bug repor
 
 ## Scope of responsibilities
 
-The objective of the team is to help spread work beyond the [Mergers](https://www.djangoproject.com/foundation/teams/#mergers-team) and into the wider contributor community. A pull request approval from a member of the Triage and Review team allows a Merger to merge a minor change that they, themselves have primarily authored.
+The objective of the team is to help spread work beyond the [Mergers](https://www.djangoproject.com/foundation/teams/#mergers-team) and into the wider contributor community. The team has elevated permissions in Trac and GitHub to allow them to triage and maintain tickets and pull requests. A pull request approval from a member of the Triage and Review team allows a Merger to merge a minor change that they, themselves have primarily authored.
 
 Team members will:
 

--- a/active/triage-and-review.md
+++ b/active/triage-and-review.md
@@ -1,0 +1,61 @@
+# Triage and Review Team
+
+The Triage & Review Team assists with the processing of pull requests.
+
+## Scope of responsibilities
+
+The objective of the team is to help spread work beyond the [Mergers](https://www.djangoproject.com/foundation/teams/#mergers-team) and into the wider contributor community. A pull request approval from a member of the Triage and Review team allows a Merger to merge a minor change.
+
+Team members will:
+
+- Triage tickets according to the [documented process](https://docs.djangoproject.com/en/dev/internals/contributing/triaging-tickets/).
+- Review patches to ensure they adhere to the [documented guidelines](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/submitting-patches/#patch-review-checklist).
+- Monitor active contributors to invite as Triage & Review team members.
+
+## Initial membership
+
+- Chair:
+- Co-Chair:
+- Steering Council Liaison (must be an active Steering Council member; may be the same as Chair/Co-Chair):
+- Other members:
+  - Clifford Gama
+  - David Sanders
+  - Hasan Ramezani
+  - Jacob Walls
+  - Lily Foote
+  - Mariusz Felisiak
+  - Natalia Bidart
+  - Nick Pope
+  - Sarah Boyce
+  - SiHyunLee
+  - Simon Charette
+
+
+## Future membership
+
+Anyone actively engaging in discussions on GitHub, the Forum and/or the new-features repository will be eligible to join the Triage and Review Team.
+
+The membership will operate as follows:
+- Any existing member can invite an active contributor to join the team
+- Each year, every non-Fellow member will need to reaffirm their membership with the team
+
+There are [instructions on how to add new members to the team in the Wiki](https://code.djangoproject.com/wiki/TriageReviewTeam#HowtoaddamembertotheTriageReviewTeam).
+
+## Budget
+
+There is no budget, but requests can be made to the Board as needs arise.
+
+Django has some professional PyCharm licenses that we can share with our contributors. Team members are eligible receive these.
+
+## Comms
+
+The team can be mentioned in the following ways:
+- [GitHub team](https://github.com/orgs/django/teams/triage-review)
+
+The team communicates on the following channels:
+- [Mailing list](https://groups.google.com/a/djangoproject.com/g/triage-review/members)
+- [Private Discord `#triage-review` channel](https://chat.djangoproject.com/)
+
+## Reporting
+
+The team does not produce reports at this time.

--- a/active/triage-and-review.md
+++ b/active/triage-and-review.md
@@ -1,6 +1,6 @@
 # Triage and Review Team
 
-The Triage & Review Team assists with the processing of pull requests, bug reports, and feature requests.
+The Triage & Review Team assists with the processing of pull requests, bug reports, and feature requests. Members of this team are contributors who regularly step up to help with the invisible work of maintaining the Django framework.
 
 ## Scope of responsibilities
 


### PR DESCRIPTION
This was proposed on django/dsf-working-groups at: https://github.com/django/dsf-working-groups/pull/79

This is part of the DSF's effort to standarize the technical teams.

This is largely a reproduction of the documented processes in DEP 10. However there are some small changes / things that should be discussed:

- [new] Explicit mention of monitoring active contributors to be invited as team members
- [new] PyCharm licenses mention
- "Any existing member can invite an active contributor to join the team" (the wiki suggested that there's a team approval process?)
